### PR TITLE
bugfix/fix width of graph when load dashboard

### DIFF
--- a/src/components/Dashboard/DashboardContent/DashboardContent.scss
+++ b/src/components/Dashboard/DashboardContent/DashboardContent.scss
@@ -1,8 +1,9 @@
 @import "src/styles/utils";
 
 .DashboardContent-wrapper {
+	@include page-wrapper;
+
 	height: fit-content;
-	margin: 15px auto 70px;
 	$linkWrapperHeight: 288px;
 
 	.PriceGraphClickable-wrapper {


### PR DESCRIPTION
Sửa lỗi: Khi mới load Dashboard đồ thị bị thu hẹp, ấn nút chuyển Price/Volume mới giãn ra đủ