### PR TITLE
fix: crash due to cant get event from parse message

### DIFF
--- a/src/components/Tx/TxData/TxMessage/TxMessage.js
+++ b/src/components/Tx/TxData/TxMessage/TxMessage.js
@@ -312,7 +312,7 @@ const TxMessage = ({ key, msg, data, ind }) => {
 			} catch (error) {
 				messageParse = [{ error: rawLog }];
 			} finally {
-				const { events } = messageParse?.[0] || { events: [] };
+				const { events = [] } = messageParse?.[0] || { events: [] };
 				return (
 					<InfoRow label='RawLog'>
 						{!isLargeScreen ? (


### PR DESCRIPTION
fix: crash due to cant get event from parse message